### PR TITLE
css: use nearest-neighbor canvas scaling

### DIFF
--- a/BasiliskII/src/Unix/BasiliskII-mainthread.html
+++ b/BasiliskII/src/Unix/BasiliskII-mainthread.html
@@ -28,6 +28,7 @@
         border: 0px none;
         background-color: black;
         cursor: none;
+        image-rendering: pixelated;
       }
       h1 {
         font-size: 20px;


### PR DESCRIPTION
Hi! Thank you for demonstrating what a modern browser is capable of... in such a beautiful way!

I may be a bit late to the party, but the canvas looks blurry on HiDPI displays. Here goes a one-line CSS fix to force nearest-neighbor canvas scaling. Tested in FF and Chromium, looks okay in both. 

Before and after:

<img width="283" alt="before" src="https://user-images.githubusercontent.com/10712045/221175173-57802f5b-a589-4cf7-b296-59d0a2f52ac3.png"><img width="283" alt="after" src="https://user-images.githubusercontent.com/10712045/221175141-5fd8988e-9939-4c5f-8bea-6867b5eb2951.png">